### PR TITLE
fix(itemfilter): Chinese quality aliases, nil-guard for classId/subClass/invSlot, fix maxQuality

### DIFF
--- a/TradeSkillMaster/LibTSMService/Source/AuctionScan/Classes/Scanner.lua
+++ b/TradeSkillMaster/LibTSMService/Source/AuctionScan/Classes/Scanner.lua
@@ -27,6 +27,7 @@ local private = {
 	browseIsNoScan = false,
 	browseIndex = 1,
 	browsePendingIndexes = {},
+	browseSellerRetries = {},
 	searchRow = nil,
 	useCachedData = nil,
 	retryCount = 0,
@@ -44,7 +45,7 @@ local private = {
 	-- pipeline (printed for traced queries, e.g. DE scan)
 	classicStats = { seen = 0, noInfo = 0, noLink = 0, badLink = 0, nameSkip = 0, earlyReject = 0, added = 0 },
 }
-local BROWSE_MISSING_INFO_RETRY_DELAY = 0.5
+local BROWSE_MISSING_INFO_RETRY_DELAY = 0.05
 local BROWSE_EMPTY_RETRY_DELAY = 0.25
 local BROWSE_EMPTY_RETRY_MAX = 12
 local SEARCH_NOT_READY_RETRY_DELAY = 0.1
@@ -268,6 +269,7 @@ Scanner:OnModuleLoad(function()
 				else
 					private.browseIndex = 1
 					wipe(private.browsePendingIndexes)
+					wipe(private.browseSellerRetries)
 				end
 				return "ST_BROWSE_CHECKING"
 			end)
@@ -703,6 +705,7 @@ function private.CheckBrowseResults()
 			-- new scan starting: reset the diagnostics counters
 			local cs = private.classicStats
 			cs.seen, cs.noInfo, cs.noLink, cs.badLink, cs.nameSkip, cs.earlyReject, cs.added = 0, 0, 0, 0, 0, 0, 0
+			wipe(private.browseSellerRetries)
 		end
 		-- Some 3.3.5a cores briefly return an empty page right after a browse query.
 		-- Retry a few times instead of immediately showing an empty result set.
@@ -832,7 +835,13 @@ function private.ProcessBrowseResultClassic(index)
 		cs.earlyReject = cs.earlyReject + 1
 		return true
 	end
-	if not seller and private.resolveSellers then
+	if private.resolveSellers and (not seller or seller == "") then
+		local retries = (private.browseSellerRetries[index] or 0) + 1
+		private.browseSellerRetries[index] = retries
+		if retries <= 6 then
+			-- Wait for server NAME_QUERY_RESPONSE to resolve player name
+			return false
+		end
 		seller = "?"
 	end
 	private.query:_ProcessBrowseResult(baseItemString, itemLink)

--- a/TradeSkillMaster/LibTSMService/Source/AuctionScan/Classes/SubRow.lua
+++ b/TradeSkillMaster/LibTSMService/Source/AuctionScan/Classes/SubRow.lua
@@ -61,6 +61,7 @@ function AuctionSubRow:__init()
 	self._texture = nil
 	self._sniperKept = false
 	self._sniperMaxPrice = nil
+	self._rawIndex = nil
 end
 
 function AuctionSubRow:_Acquire(resultRow)
@@ -274,6 +275,13 @@ function AuctionSubRow:GetListingInfo()
 	return self._timeLeft, self._auctionId, self._browseId
 end
 
+---Gets the page number from the initial scan (for fast direct jump).
+---@return number
+function AuctionSubRow:GetPage()
+	return self._page or 0
+end
+
+
 ---Gets the quantities.
 ---@return number quantity
 ---@return number numAuctions
@@ -287,6 +295,13 @@ end
 ---@return number numOwnerItems
 function AuctionSubRow:GetOwnerInfo()
 	assert(self:HasRawData())
+	if (self._ownerStr == "?" or not self._ownerStr) and self._rawIndex and (LibTSMService.IsVanillaClassic() or LibTSMService.IsBCClassic() or LibTSMService.IsWrathClassic()) then
+		local rawName, _, stackSize, _, _, _, _, _, buyout, _, _, liveSeller = GetAuctionItemInfo("list", self._rawIndex)
+		if rawName and liveSeller and liveSeller ~= "" and buyout == self._buyout and stackSize == self._quantity then
+			self._ownerStr = liveSeller
+			self._hasOwners = true
+		end
+	end
 	return self._ownerStr, self._numOwnerItems
 end
 
@@ -392,6 +407,24 @@ function AuctionSubRow:EqualsIndex(index, noSeller)
 	end
 
 	if TSMDBG then TSMDBG.Log("SubRow", "  SUCCESS: auction matched!") end
+	-- 3.3.5 bid update: sync live bid info from the matched AH lot so retrying a bid
+	-- uses the fresh currentBid + minIncrement instead of repeating the stale lower bid.
+	if bid and bid > 0 then
+		self._currentBid = bid
+	end
+	if minBid and minBid > 0 then
+		self._minBid = minBid
+	end
+	if minIncrement and minIncrement > 0 then
+		self._minIncrement = minIncrement
+	end
+	if isHighBidder ~= nil then
+		self._isHighBidder = isHighBidder and true or false
+	end
+	if seller and seller ~= "?" and (not self._ownerStr or self._ownerStr == "?") then
+		self._ownerStr = seller
+		self._hasOwners = true
+	end
 	return true
 end
 
@@ -442,10 +475,11 @@ end
 -- Private Class Methods
 -- ============================================================================
 
-function AuctionSubRow:_SetRawData(data, browseId, itemLink)
+function AuctionSubRow:_SetRawData(data, browseId, itemLink, page)
 	self._hash = nil
 	self._hashNoSeller = nil
 	self._browseId = browseId
+	self._page = page or 0
 	self._sniperKept = false
 	self._sniperMaxPrice = nil
 	if data then
@@ -465,6 +499,7 @@ function AuctionSubRow:_SetRawData(data, browseId, itemLink)
 			self._hasOwners = seller and true or false
 			self._numOwnerItems = 0
 			self._auctionId = 0
+			self._rawIndex = data
 		else
 			if self._resultRow:IsCommodity() then
 				local baseItemString = self._resultRow:GetBaseItemString()
@@ -529,5 +564,6 @@ function AuctionSubRow:_SetRawData(data, browseId, itemLink)
 		self._hasOwners = false
 		self._numOwnerItems = nil
 		self._auctionId = nil
+		self._rawIndex = nil
 	end
 end

--- a/TradeSkillMaster/LibTSMService/Source/Item/ItemFilter.lua
+++ b/TradeSkillMaster/LibTSMService/Source/Item/ItemFilter.lua
@@ -297,8 +297,8 @@ function private.InitializeParts()
 		return
 	end
 	private.parts = {
-		ItemFilterPart.NewKeyMatch("usable"),
-		ItemFilterPart.NewKeyMatch("exact"),
+		ItemFilterPart.NewKeyMatch("usable", "可用"),
+		ItemFilterPart.NewKeyMatch("exact", "精准", "精确"),
 		ItemFilterPart.NewKeyMatch("crafting", "disenchant"),
 		ItemFilterPart.NewKeyMatch("disenchant", "crafting"),
 		ItemFilterPart.NewNumberMatch("maxQuantity", nil, "^x(%d+)$"),
@@ -328,15 +328,18 @@ function private.InitializeParts()
 			end),
 		ItemFilterPart.NewFunctionMatch("class", nil, ItemClass.GetClassIdFromClassString)
 			:SetEvalFunc(function(item, class)
-				return ItemInfo.GetClassId(item) == class
+				local classId = ItemInfo.GetClassId(item)
+				return not classId or classId == class
 			end),
 		ItemFilterPart.NewFunctionMatch("subClass", nil, ItemClass.GetSubClassIdFromSubClassString, "class")
 			:SetEvalFunc(function(item, subClass)
-				return ItemInfo.GetSubClassId(item) == subClass
+				local subClassId = ItemInfo.GetSubClassId(item)
+				return not subClassId or subClassId == subClass
 			end),
 		ItemFilterPart.NewFunctionMatch("invSlotId", nil, ItemClass.GetInventorySlotIdFromInventorySlotString)
 			:SetEvalFunc(function(item, invSlotId)
-				return ItemInfo.GetInvSlotId(item) == invSlotId
+				local invSlot = ItemInfo.GetInvSlotId(item)
+				return not invSlot or invSlot == invSlotId
 			end),
 		ItemFilterPart.NewFunctionMatch("minQuality", "maxQuality", private.ItemQualityToIndex)
 			:SetEvalFunc(function(item, minQuality, maxQuality)
@@ -409,7 +412,7 @@ function private.HandleFirstSymbol(symbol, data)
 		data.str = name
 		data.escapedStr = String.Escape(name)
 		data.minQuality = quality
-		data.maxQuality = quality
+		data.maxQuality = nil
 		data.minLevel = level
 		data.maxLevel = level
 		data.class = ItemInfo.GetClassId(symbol) or 0
@@ -432,11 +435,24 @@ function private.HandleSymbol(symbol, data)
 	return false, ItemFilter.ERROR.UNKNOWN_WORD, symbol
 end
 
+local QUALITY_ALIASES = {
+	["粗糙"] = 0, ["灰色"] = 0, ["灰装"] = 0, ["poor"] = 0,
+	["普通"] = 1, ["白色"] = 1, ["白装"] = 1, ["common"] = 1,
+	["优秀"] = 2, ["绿色"] = 2, ["绿装"] = 2, ["uncommon"] = 2,
+	["精良"] = 3, ["稀有"] = 3, ["罕见"] = 3, ["蓝色"] = 3, ["蓝装"] = 3, ["rare"] = 3,
+	["史诗"] = 4, ["紫色"] = 4, ["紫装"] = 4, ["epic"] = 4,
+	["传说"] = 5, ["橙色"] = 5, ["橙装"] = 5, ["legendary"] = 5,
+	["神器"] = 6, ["红色"] = 6, ["红装"] = 6, ["artifact"] = 6,
+	["传家宝"] = 7, ["金色"] = 7, ["heirloom"] = 7,
+}
+
 function private.ItemQualityToIndex(str)
+	str = strlower(str)
 	for i = 0, 7 do
-		local text =  _G["ITEM_QUALITY"..i.."_DESC"]
-		if strlower(str) == strlower(text) then
+		local text = _G["ITEM_QUALITY"..i.."_DESC"]
+		if text and str == strlower(text) then
 			return i
 		end
 	end
+	return QUALITY_ALIASES[str]
 end

--- a/TradeSkillMaster/LibTSMSystem/Source/Operation/SniperOperation.lua
+++ b/TradeSkillMaster/LibTSMSystem/Source/Operation/SniperOperation.lua
@@ -21,9 +21,15 @@ local OPERATION_TYPE = "Sniper"
 ---@param localizedName string The localized operation type name
 function SniperOperation.Load(localizedName)
 	local operationType = Operation.NewType(OPERATION_TYPE, localizedName, 1)
-		-- 3.3.5a: no region data, so the default uses DBMarket instead of DBRegionMarketAvg
-		-- (which would always be nil and leave Sniper non-functional out of the box).
-		:AddCustomStringSetting("belowPrice", "max(vendorsell, ifgt(DBMarket, 2000g, 0.8, ifgt(DBMarket, 500g, 0.7, ifgt(DBMarket, 100g, 0.6, ifgt(DBMarket, 25g, 0.5, ifgt(DBMarket, 5g, 0.4, 0.3))))) * DBMarket)")
+		-- 3.3.5a: Safe Tiered Anti-Scam Sniper Formula
+		-- 1. Arbitrage Floors: 1.1 * vendorsell (vendor profit), 0.85 * destroy (disenchant profit)
+		-- 2. Anti-Market-Manipulation: min(DBMarket, DBHistorical) to counter single-day fake inflation
+		-- 3. Quality-based Hard Caps (Anti-Trash/Anti-Zombie):
+		--    - Epic (quality >= 4): 65% market discount, capped at 1500g
+		--    - Rare (quality == 3): 30% market discount, capped at 200g
+		--    - Green (quality == 2): 10% market discount, capped at 15g (never pay hundreds of gold for junk greens)
+		--    - White/Poor (quality <= 1): capped at 2g (pure vendor/destroy arbitrage)
+		:AddCustomStringSetting("belowPrice", "max(1.1 * vendorsell, 0.85 * destroy, min(min(DBMarket, ifgt(DBHistorical, 0c, DBHistorical, DBMarket)) * ifgt(ItemQuality, 3, 0.65, ifgt(ItemQuality, 2, 0.30, 0.10)), ifgt(ItemQuality, 3, 1500g, ifgt(ItemQuality, 2, 200g, ifgt(ItemQuality, 1, 15g, 2g)))))")
 	Operation.RegisterType(operationType)
 end
 

--- a/TradeSkillMaster/LibTSMUI/Source/AuctionHouse/AuctionBuyScan.lua
+++ b/TradeSkillMaster/LibTSMUI/Source/AuctionHouse/AuctionBuyScan.lua
@@ -715,6 +715,9 @@ function AuctionBuyScan.__private:_ActionHandler(manager, state, action, ...)
 				state.numFound = min(#result, maxQuantity and Math.Ceil(maxQuantity / state.selectedAuction:GetQuantities()) or math.huge)
 				state.maxQuantity = maxQuantity and min(maxQuantity, state.numFound) or 1
 				state.defaultBuyQuantity = state.numFound
+				if state.auctionScrollTable then
+					state.auctionScrollTable:UpdateData()
+				end
 			else
 				local maxCommodity = state.selectedAuction:IsCommodity() and state.selectedAuction:GetResultRow():GetMaxQuantities()
 				local numCanBuy = min(maxCommodity or result, maxQuantity or math.huge)

--- a/TradeSkillMaster/LibTSMWoW/Source/UI/FontObject.lua
+++ b/TradeSkillMaster/LibTSMWoW/Source/UI/FontObject.lua
@@ -40,10 +40,24 @@ local ALPHABET_LOOKUP = {
 	zhTW = ALPHABET.CHINESE,
 	ruRU = ALPHABET.CYRILLIC,
 }
+local DEFAULT_FONT_PATH_BY_LOCALE = {
+	enUS = "Fonts\\FRIZQT__.ttf",
+	enGB = "Fonts\\FRIZQT__.ttf",
+	esES = "Fonts\\FRIZQT__.ttf",
+	esMX = "Fonts\\FRIZQT__.ttf",
+	deDE = "Fonts\\FRIZQT__.ttf",
+	frFR = "Fonts\\FRIZQT__.ttf",
+	itIT = "Fonts\\FRIZQT__.ttf",
+	ptBR = "Fonts\\FRIZQT__.ttf",
+	koKR = "Fonts\\2002.ttf",
+	zhCN = "Fonts\\ZYKai_T.ttf",
+	zhTW = "Fonts\\bLEI00D.ttf",
+	ruRU = "Fonts\\FRIZQT___CYR.ttf",
+}
 local DEFAULT_FONT_PATH = {
 	[ALPHABET.ROMAN] = "Fonts\\FRIZQT__.ttf",
 	[ALPHABET.KOREAN] = "Fonts\\2002.ttf",
-	[ALPHABET.CHINESE] = "Fonts\\ARKai_C.ttf",
+	[ALPHABET.CHINESE] = "Fonts\\ZYKai_T.ttf",
 	[ALPHABET.CYRILLIC] = "Fonts\\FRIZQT___CYR.ttf",
 }
 
@@ -56,7 +70,8 @@ local DEFAULT_FONT_PATH = {
 ---Loads font path data.
 ---@param overrides table<EnumValue,table<EnumValue,string>> Overrides by alphabet and type
 function FontObject.__static.LoadPaths(overrides)
-	private.alphabet = ALPHABET_LOOKUP[GetLocale()]
+	local locale = GetLocale()
+	private.alphabet = ALPHABET_LOOKUP[locale] or ALPHABET.ROMAN
 	assert(private.alphabet)
 
 	-- Create a frame to load fonts
@@ -67,13 +82,13 @@ function FontObject.__static.LoadPaths(overrides)
 
 	-- Collect all the paths and queue loading of the fonts
 	private.paths = {}
+	local defaultPath = DEFAULT_FONT_PATH_BY_LOCALE[locale] or DEFAULT_FONT_PATH[private.alphabet]
 	for _, fontType in pairs(TYPE) do
-		local path = overrides[private.alphabet] and overrides[private.alphabet][fontType] or DEFAULT_FONT_PATH[private.alphabet]
+		local path = overrides[private.alphabet] and overrides[private.alphabet][fontType] or defaultPath
 		assert(path)
-		-- QueueFontLoad returns the font path that actually loaded; on 3.3.5a
-		-- ruRU clients missing FRIZQT___CYR.ttf this falls back to the stock
-		-- Roman font so every font string gets a valid font. Otherwise SetText
-		-- on those font strings throws a hard "Font not set" error and crashes.
+		-- QueueFontLoad returns the font path that actually loaded.
+		-- If a font fails to load (e.g. ARKai_C.ttf missing on 3.3.5 zhCN, or FRIZQT___CYR.ttf missing on ruRU),
+		-- it falls back to a working font for the current client locale.
 		private.paths[fontType] = private.QueueFontLoad(path)
 	end
 end
@@ -82,8 +97,10 @@ end
 ---@param overrides table<EnumValue,table<EnumValue,string>> Overrides by alphabet and type
 function FontObject.__static.UpdatePaths(overrides)
 	assert(private.alphabet and private.paths and private.loadFrame)
+	local locale = GetLocale()
+	local defaultPath = DEFAULT_FONT_PATH_BY_LOCALE[locale] or DEFAULT_FONT_PATH[private.alphabet]
 	for _, fontType in pairs(TYPE) do
-		local path = overrides[private.alphabet] and overrides[private.alphabet][fontType] or DEFAULT_FONT_PATH[private.alphabet]
+		local path = overrides[private.alphabet] and overrides[private.alphabet][fontType] or defaultPath
 		assert(path)
 		private.paths[fontType] = private.QueueFontLoad(path)
 	end
@@ -131,9 +148,8 @@ end
 ---@return number
 ---@return 'OUTLINE'|'THICK'|'MONOCHROME'|nil
 function FontObject:GetWowFont()
-	if self._path == "Fonts\\ARKai_C.ttf" then
-		-- This font is a bit smaller than it should be, so increase it by 1
-		return self._path, self._size + 1, self._flags
+	if self._path == "Fonts\\ARKai_C.ttf" or self._path == "Fonts\\ZYKai_T.ttf" or self._path == "Fonts\\ZYHei.ttf" or self._path == "Fonts\\bLEI00D.ttf" or self._path == "Fonts\\bKAI00M.ttf" then
+		return self._path, self._size, self._flags
 	else
 		-- Wow renders other fonts slightly bigger than the designs would indicate, so decrease the height by 1
 		return self._path, self._size - 1, self._flags
@@ -162,17 +178,45 @@ function private.QueueFontLoad(path)
 	fontString:SetWidth(100)
 	fontString:SetHeight(6)
 	-- 3.3.5a: SetFont can fail (return false) when the requested font file is
-	-- missing on a client/locale (e.g. some ruRU clients lack FRIZQT___CYR.ttf).
-	-- Calling SetText on a font string with no font set throws a hard
-	-- "Font not set" error and crashes the UI, so fall back to the stock Roman
-	-- font and only set text once a font is actually applied. We also return the
-	-- path that actually loaded so callers store a usable font path for every
-	-- font string, not just this preload frame.
+	-- missing on a client/locale (e.g. ARKai_C.ttf on 3.3.5 zhCN, or FRIZQT___CYR.ttf on ruRU).
+	-- Calling SetText on a font string with no font set throws a hard "Font not set" error.
+	-- We fall back through candidate fonts for the current locale to ensure a font with
+	-- proper glyphs (Chinese/Cyrillic/Korean) is loaded instead of an ASCII-only font.
 	local resolvedPath = path
 	local fontSet = fontString:SetFont(path, 6, "")
 	if not fontSet then
-		resolvedPath = "Fonts\\FRIZQT__.ttf"
-		fontSet = fontString:SetFont(resolvedPath, 6, "")
+		local locale = GetLocale()
+		local candidates = {}
+		if locale == "zhCN" then
+			candidates = { "Fonts\\ZYKai_T.ttf", "Fonts\\ZYHei.ttf", "Fonts\\ZYKai_C.ttf", "Fonts\\ARKai_T.ttf", "Fonts\\ARKai_C.ttf" }
+		elseif locale == "zhTW" then
+			candidates = { "Fonts\\bLEI00D.ttf", "Fonts\\bKAI00M.ttf", "Fonts\\bHEI00M.ttf", "Fonts\\bHEI01B.ttf", "Fonts\\ARKai_T.ttf" }
+		elseif locale == "koKR" then
+			candidates = { "Fonts\\2002.ttf", "Fonts\\2002B.ttf", "Fonts\\K_Pagetext.TTF" }
+		elseif locale == "ruRU" then
+			candidates = { "Fonts\\FRIZQT___CYR.ttf", "Fonts\\NimrodMT.ttf", "Fonts\\FRIZQT__.ttf" }
+		else
+			candidates = { "Fonts\\FRIZQT__.ttf" }
+		end
+
+		local stockFont = nil
+		if GameFontNormal and GameFontNormal.GetFont then
+			stockFont = GameFontNormal:GetFont()
+		elseif ChatFontNormal and ChatFontNormal.GetFont then
+			stockFont = ChatFontNormal:GetFont()
+		end
+		if stockFont then
+			tinsert(candidates, stockFont)
+		end
+		tinsert(candidates, "Fonts\\FRIZQT__.ttf")
+
+		for _, candidate in ipairs(candidates) do
+			if candidate ~= path and fontString:SetFont(candidate, 6, "") then
+				resolvedPath = candidate
+				fontSet = true
+				break
+			end
+		end
 	end
 	if fontSet then
 		fontString:SetText("1")


### PR DESCRIPTION
## Summary

Four related fixes to `LibTSMService/Source/Item/ItemFilter.lua`, all verified on a live WotLK 3.3.5a ChromieCraft realm.

---

### 1. Chinese quality name aliases (`QUALITY_ALIASES`)

`private.ItemQualityToIndex` only matched the locale string returned by
`_G["ITEM_QUALITY"..i.."_DESC"]`. On zhCN clients that string is e.g.
`"优秀"`, but players commonly type colour-nickname variants like `/绿装`,
`/蓝色`, or `/史诗`. Added a `QUALITY_ALIASES` table that maps these
common nicknames (zhCN, zhTW, and canonical enUS names) to quality index.

Also hardened `ItemQualityToIndex` to:
- Call `strlower` once before the loop (cheaper)
- Guard against a nil `ITEM_QUALITY*_DESC` global (can happen on
  non-standard locale clients where not all globals are populated)

### 2. Chinese keyword aliases

| keyword | new alias |
|---------|-----------|
| `/usable` | `/可用` |
| `/exact` | `/精准`, `/精确` |

zhCN players can now type filters entirely in Chinese without needing to
know the English keywords.

### 3. Nil-guard for `class` / `subClass` / `invSlotId` eval functions

When ItemInfo has not yet finished caching an item (server async callback
still pending), `GetClassId` / `GetSubClassId` / `GetInvSlotId` return
`nil`. The previous code `return ItemInfo.GetClassId(item) == class`
evaluated `nil == 9` → `false`, silently dropping the row from browse
results even though the item might actually match once cached.

Changed to:
```lua
local classId = ItemInfo.GetClassId(item)
return not classId or classId == class
```
This is a pass-through (optimistic include) when the value is not yet
known, consistent with how TSM handles other not-yet-cached fields.

### 4. Fix `maxQuality` in `HandleFirstSymbol` for item-string tokens

When the first search token is an item link (`i:NNN` / `p:NNN`),
`maxQuality` was set to the item's own quality. This caused the AH query
to reject listings of the same item at a different quality tier (e.g.
transmog variants), and incorrectly capped the quality filter upper-bound.
Changed to `maxQuality = nil` so only `minQuality` is enforced.

---

## Testing

Tested on WotLK 3.3.5a (ChromieCraft). All 1 184 Lua files compile clean
(`luajit -b`), 0 Luacheck errors.