### PR TITLE
fix(core, crafting): TempTable pool resilience and profession UI/State guards on 3.3.5a

### DIFF
--- a/TradeSkillMaster/LibTSMService/Source/Profession/Classes/Scanner.lua
+++ b/TradeSkillMaster/LibTSMService/Source/Profession/Classes/Scanner.lua
@@ -965,7 +965,9 @@ end
 
 function private.PopulateClassicSpellIdLookup()
 	assert(not ClientInfo.HasFeature(ClientInfo.FEATURES.C_TRADE_SKILL_UI))
-	assert(State.GetCurrentProfession() and TradeSkill.IsDataReady())
+	if not State.GetCurrentProfession() or not TradeSkill.IsDataReady() then
+		return
+	end
 	wipe(private.classicSpellIdLookup)
 	for i, name in TradeSkill.RecipeIterator() do
 		local hash = Hash.Calculate(name)
@@ -977,17 +979,22 @@ function private.PopulateClassicSpellIdLookup()
 			hash = Hash.Calculate(ItemString.Get(itemLink), hash)
 			hash = Hash.Calculate(quantity, hash)
 		end
+		if hash < 0 then
+			hash = abs(hash)
+		end
 		if private.classicSpellIdLookup[hash] then
 			local itemString, craftName = private.GetItemStringAndCraftName(CraftString.Get(hash))
 			local spellId = Scanner.GetClassicSpellId(hash)
-			local itemLink, indirectSpellId = TradeSkill.GetResult(spellId)
-			Log.Err("Hash already exists %d, %d, %d, %s, %s, %s, %s", hash, spellId, TradeSkill.GetIcon(spellId), craftName, itemLink, tostring(indirectSpellId), itemString)
-			for j = 1, TradeSkill.GetNumMats(spellId) do
-				local link, _, quantity = TradeSkill.GetMatInfo(spellId, nil, j)
-				Log.Err("Material %d: %s, %s, %d", j, link, ItemString.Get(link), quantity)
+			Log.Warn("Hash collision for %d (%s) with %s (%s)", i, name, tostring(itemString), tostring(craftName))
+			local collisionCount = 1
+			while private.classicSpellIdLookup[hash] do
+				hash = Hash.Calculate(i + collisionCount * 10000, hash)
+				if hash < 0 then
+					hash = abs(hash)
+				end
+				collisionCount = collisionCount + 1
 			end
 		end
-		assert(hash >= 0 and not private.classicSpellIdLookup[hash] and not private.classicSpellIdLookup[-i])
 		private.classicSpellIdLookup[hash] = i
 		private.classicSpellIdLookup[-i] = hash
 	end

--- a/TradeSkillMaster/LibTSMService/Source/Profession/Classes/State.lua
+++ b/TradeSkillMaster/LibTSMService/Source/Profession/Classes/State.lua
@@ -158,7 +158,11 @@ function private.CreateFSM()
 		:AddState(FSM.NewState("ST_SHOWN")
 			:SetOnEnter(function()
 				local name, skillId = TradeSkill.GetName()
-				assert(name)
+				if not name then
+					Log.Warn("TradeSkill name is nil, ignoring show")
+					private.fsm:ProcessEvent("EV_TRADE_SKILL_CLOSE")
+					return
+				end
 				Log.Info("Showing profession: %s (%s)", name, tostring(skillId))
 				private.professionName = name
 				private.skillId = skillId

--- a/TradeSkillMaster/LibTSMUtil/Source/BaseType/TempTable.lua
+++ b/TradeSkillMaster/LibTSMUtil/Source/BaseType/TempTable.lua
@@ -56,10 +56,11 @@ end)
 function TempTable.Acquire(...)
 	local tbl = next(private.free)
 	if not tbl then
-		error("Could not acquire temp table")
+		tbl = {}
+	else
+		private.free[tbl] = nil
+		setmetatable(tbl, nil)
 	end
-	private.free[tbl] = nil
-	setmetatable(tbl, nil)
 	if private.debugLeaks then
 		private.state[tbl] = (DebugStack.GetLocation(2) or "?").." -> "..(DebugStack.GetLocation(3) or "?")
 	else

--- a/TradeSkillMaster/LibTSMWoW/Source/API/TradeSkill.lua
+++ b/TradeSkillMaster/LibTSMWoW/Source/API/TradeSkill.lua
@@ -255,7 +255,10 @@ function TradeSkill.GetName()
 		local info = C_TradeSkillUI.GetBaseProfessionInfo()
 		return info.parentProfessionName or info.professionName, info.profession
 	else
-		local name = TradeSkill.IsClassicCrafting() and GetCraftSkillLine(1) or GetTradeSkillLine()
+		local name = TradeSkill.IsClassicCrafting() and GetCraftSkillLine(1) or (GetTradeSkillLine and GetTradeSkillLine())
+		if name == "UNKNOWN" or name == "" then
+			name = nil
+		end
 		return name
 	end
 end
@@ -342,8 +345,8 @@ function TradeSkill.GetResult(spellId)
 		if LibTSMWoW.IsPandaClassic() then
 			itemLink = itemLink or GetTradeSkillRecipeLink(spellId)
 		end
-		local indirectSpellId = strmatch(itemLink, "enchant:(%d+)")
-		if not indirectSpellId then
+		local indirectSpellId = itemLink and strmatch(itemLink, "enchant:(%d+)") or nil
+		if not indirectSpellId and itemLink then
 			indirectResultId = strmatch(itemLink, "item:(%d+)") or strmatch(itemLink, "spell:(%d+)")
 		end
 		indirectSpellId = indirectSpellId and tonumber(indirectSpellId)
@@ -468,7 +471,7 @@ end
 ---Iterates over the available trade skill recipes (must be run to completion).
 ---@return fun(): number, string?, number?, EnumValue?, TradeSkillRecipeInfo? @Iterator with fields: `index`, `name`, `categoryId`, `difficulty`, `info`
 function TradeSkill.RecipeIterator()
-	assert(not next(private.iteratorContext))
+	wipe(private.iteratorContext)
 	if ClientInfo.HasFeature(ClientInfo.FEATURES.C_TRADE_SKILL_UI) then
 		assert(C_TradeSkillUI.GetFilteredRecipeIDs(private.iteratorContext) == private.iteratorContext)
 	else

--- a/TradeSkillMaster_Crafting/UI/CraftingUI_Core.lua
+++ b/TradeSkillMaster_Crafting/UI/CraftingUI_Core.lua
@@ -243,7 +243,8 @@ function private.FSMCreate()
 			end)
 			:AddEvent("EV_TRADE_SKILL_SHOW", function(context)
 				Profession.SetScannerDisabled(private.settings.showDefault)
-				if CraftingUI.IsProfessionIgnored(TradeSkill.GetName()) then
+				local profName = TradeSkill.GetName()
+				if not profName or CraftingUI.IsProfessionIgnored(profName) then
 					return "ST_DEFAULT_OPEN", true
 				elseif private.settings.showDefault then
 					return "ST_DEFAULT_OPEN"
@@ -310,7 +311,8 @@ function private.FSMCreate()
 				return "ST_CLOSED"
 			end)
 			:AddEvent("EV_TRADE_SKILL_SHOW", function(context)
-				if CraftingUI.IsProfessionIgnored(TradeSkill.GetName()) then
+				local profName = TradeSkill.GetName()
+				if not profName or CraftingUI.IsProfessionIgnored(profName) then
 					return "ST_DEFAULT_OPEN", true
 				else
 					if private.settings.showDefault then
@@ -363,7 +365,8 @@ function private.FSMCreate()
 				return "ST_CLOSED"
 			end)
 			:AddEvent("EV_TRADE_SKILL_SHOW", function(context)
-				if CraftingUI.IsProfessionIgnored(TradeSkill.GetName()) then
+				local profName = TradeSkill.GetName()
+				if not profName or CraftingUI.IsProfessionIgnored(profName) then
 					return "ST_DEFAULT_OPEN", true
 				end
 				context.frame:GetElement("titleFrame.switchBtn"):Show()

--- a/TradeSkillMaster_Crafting/UI/CraftingUI_Crafting.lua
+++ b/TradeSkillMaster_Crafting/UI/CraftingUI_Crafting.lua
@@ -432,8 +432,16 @@ function private.ActionHandler(manager, state, action, ...)
 			return
 		end
 		TSM.Crafting.InvalidateNumQueuedSmartMap()
-		state.frame:GetElement("top.left.content.recipeList"):UpdateData()
-		state.frame:GetElement("top.right.queue.queueList"):UpdateData()
+		if state.frame:HasElement("top.left.content.recipeList") then
+			state.frame:GetElement("top.left.content.recipeList"):UpdateData()
+		end
+		if state.frame:HasElement("top.right.queue.queueList") then
+			state.frame:GetElement("top.right.queue.queueList"):UpdateData()
+		end
+		local details = state.frame:HasElement("details") and state.frame:GetElement("details")
+		if details and details._acquired then
+			details:Draw()
+		end
 	elseif action == "ACTION_SKILL_UPDATE" then
 		if not state.frame then
 			return


### PR DESCRIPTION
## Summary

Six stability fixes addressing critical UI freezes, assertion failures, and fatal errors on WotLK 3.3.5a, tested and verified on live ChromieCraft realms.

---

### 1. TempTable: Elastic Allocation on Pool Exhaustion (`LibTSMUtil/Source/BaseType/TempTable.lua`)
- **Problem**: On 3.3.5a, `ItemInfo` and background tasks retain temporary tables longer due to lack of `GET_ITEM_INFO_RECEIVED` push events (polling instead). While `NUM_TEMP_TABLES` was previously bumped to 2,000, heavy AH operations or long play sessions can still exhaust the pool. When exhausted, `TempTable.Acquire` called `error("Could not acquire temp table")`. Because error handlers and `OnUpdate` loops in turn acquire temp tables, this cascaded into a recurring error loop generating thousands of errors/sec and completely freezing the WoW client UI.
- **Fix**: When `private.free` is exhausted, gracefully allocate a clean transient `{}` table instead of throwing a fatal error. When the caller invokes `TempTable.Release(tbl)`, the table is wiped, metatable set, and added to `private.free`, naturally expanding the pool to handle burst loads without crashing.

### 2. TradeSkill: Sanitize UNKNOWN/Empty String & Iterator Safety (`LibTSMWoW/Source/API/TradeSkill.lua`)
- **`GetName()`**: On 3.3.5a, `GetTradeSkillLine()` returns `"UNKNOWN"`, `""`, or `nil` when the window is closed or mid-load. `TradeSkill.GetName()` now returns `nil` in these cases instead of passing `"UNKNOWN"` to callers.
- **`GetResult()`**: Added a nil check before `strmatch(itemLink, ...)` to prevent `bad argument #1 to 'strmatch' (string expected, got nil)` when `itemLink` is nil.
- **`RecipeIterator()`**: Replaced `assert(not next(private.iteratorContext))` with `wipe(private.iteratorContext)`. If an iterator loop was previously interrupted (e.g. via `break` or an error), `private.iteratorContext` remained populated; wiping it ensures subsequent iterator calls do not crash on the assert.

### 3. Profession State: Guard `ST_SHOWN` Against Nil Profession Name (`LibTSMService/Source/Profession/Classes/State.lua`)
- **Problem**: In `State.lua`, entering `ST_SHOWN` called `local name, skillId = TradeSkill.GetName(); assert(name)`. Under network latency or rapid UI toggles, `name` can be temporarily nil, immediately throwing an assertion failure.
- **Fix**: Log a warning and transition to `EV_TRADE_SKILL_CLOSE` if `name` is nil, preventing the assertion crash.

### 4. Profession Scanner: Handle Negative Hashes & Collision Resolution Loop (`LibTSMService/Source/Profession/Classes/Scanner.lua`)
- **Problem**: In Lua 5.1 with 32-bit signed integers, `Hash.Calculate(...)` can overflow to negative numbers. `PopulateClassicSpellIdLookup()` called `assert(hash >= 0 ...)`, causing an unhandled crash whenever a recipe's computed hash was negative. Additionally, any hash collision between recipes immediately triggered an assertion failure.
- **Fix**: Added `hash = abs(hash)` safeguard, verified readiness (`State.GetCurrentProfession() and TradeSkill.IsDataReady()`), and implemented an incremental salt collision loop to rehash colliding recipes rather than crashing.

### 5. Crafting UI Core: Nil-Guard in FSM Transitions (`TradeSkillMaster_Crafting/UI/CraftingUI_Core.lua`)
- Guarded `TradeSkill.GetName()` in `EV_TRADE_SKILL_SHOW` handlers before passing into `CraftingUI.IsProfessionIgnored(profName)`. If `profName` is nil, safely falls back to `ST_DEFAULT_OPEN`.

### 6. Crafting UI Crafting: `HasElement` Defensive Checks & Details Redraw (`TradeSkillMaster_Crafting/UI/CraftingUI_Crafting.lua`)
- In `ACTION_BAG_QUANTITY_UPDATED`, verified existence of `top.left.content.recipeList` and `top.right.queue.queueList` via `HasElement` before updating data.
- Redraw `details` via `details:Draw()` if present and acquired to keep craftable quantities updated without calling missing private handlers.

---

## Testing

- Verified on live WotLK 3.3.5a client (ChromieCraft).
- All 6 modified files compile cleanly with `luajit -b` (0 syntax errors).
- All files pass Luacheck with 0 errors.